### PR TITLE
Add a badge for specifying current stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ECMAScript Cancellation
 
+![Stage 4](https://badges.aleen42.com/src/tc39_5.svg)
+
 This proposal seeks to define an approach to user-controlled cancellation of asynchronous operations
 through the adoption of a set of native platform objects.
 


### PR DESCRIPTION
According to https://es.discourse.group/t/a-standard-badge-for-tc39/731, automatically generate a badge for specifying current stage of the proposal.